### PR TITLE
Let user pass a loop device to monitor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ PROJECT := counter
 
 CLANG ?= clang
 BPFTOOL ?= bpftool
-CC ?= $(CLANG)
 CXX ?= clang++
 
 ARCH = $(shell uname -m | sed 's/x86_64/x86/' \
@@ -45,4 +44,4 @@ $(BIN): $(SRC) $(BPF_SKEL)
 
 clean:
 	@echo "  CLEAN"
-	@rm $(BPF_SKEL) $(VMLINUX) $(SRC_DIR)/*.o $(BPF_PROG) src/tracer.h $(BIN)
+	@$(RM) $(BPF_SKEL) $(VMLINUX) $(SRC_DIR)/*.o $(BPF_PROG) src/tracer.h $(BIN)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PROJECT := counter
 
 BPFTOOL = bpftool
 CC = clang
-CXX = $(CC) -x c++
+CXX = clang++
 
 ARCH = $(shell uname -m | sed 's/x86_64/x86/' \
 	   					| sed 's/aarch64/arm64/')

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ PROJECT := counter
 CLANG ?= clang
 BPFTOOL ?= bpftool
 CC ?= $(CLANG)
+CXX ?= clang++
 
 ARCH = $(shell uname -m | sed 's/x86_64/x86/' \
 	   					| sed 's/aarch64/arm64/')
@@ -39,8 +40,8 @@ $(BPF_SKEL): $(BPF_OBJ)
 	@$(BPFTOOL) gen skeleton $< > $@
 
 $(BIN): $(SRC) $(BPF_SKEL)
-	@echo "  CC      $@"
-	@$(CC) $(CFLAGS) -I$(SRC_DIR) -o $@ $< $(LDFLAGS)
+	@echo "  CXX     $@"
+	@$(CXX) $(CFLAGS) -I$(SRC_DIR) -o $@ $< $(LDFLAGS)
 
 clean:
 	@echo "  CLEAN"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If running inside toolbx containers, this [Containerfile](https://github.com/jo5
 
 ## Run
 
-- `sudo src/counter`
+- `sudo src/counter <path to block device>`
 
 ## Generated Report
 

--- a/scripts/generate_bpf_programs.sh
+++ b/scripts/generate_bpf_programs.sh
@@ -52,13 +52,6 @@ generate_bpf_program() {
 
 char LICENSE[] SEC("license") = "Dual BSD/GPL";
 
-struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
-	__type(key, u32);
-	__type(value, struct iofilter_dev);
-	__uint(max_entries, 1);
-} iofilter SEC(".maps");
-
 struct { 
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__type(key, u32);

--- a/scripts/generate_bpf_programs.sh
+++ b/scripts/generate_bpf_programs.sh
@@ -41,14 +41,23 @@ EOF
 }
 
 generate_bpf_program() {
-	local it=0
-		cat > "src/$FILE_HDR.bpf.c" <<EOF
+	cat > "src/$FILE_HDR.bpf.c" <<EOF
 #include "vmlinux.h"
+#include <bpf/bpf_core_read.h>
 #include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
 
+#include "iofilter.h"
 #include "tracer.h"
 
 char LICENSE[] SEC("license") = "Dual BSD/GPL";
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, u32);
+	__type(value, struct iofilter_dev);
+	__uint(max_entries, 1);
+} iofilter SEC(".maps");
 
 struct { 
 	__uint(type, BPF_MAP_TYPE_HASH);
@@ -57,8 +66,25 @@ struct {
 	__uint(max_entries, NUM_KSYMS);
 } syscall_count SEC(".maps");
 
-int increment_counter(u32 key) { 
+int increment_counter(u32 key, struct pt_regs *ctx) {
 	static const u64 init = 1;
+	static const u64 dev_key = 0;
+
+	struct iofilter_dev *iodev = bpf_map_lookup_elem(&iofilter, &dev_key);
+	if (!iodev) {
+		return 0;
+	}
+
+	struct file *file = (struct file *)PT_REGS_PARM1(ctx);
+	struct inode *inode = BPF_CORE_READ(file, f_inode);
+	dev_t dev = BPF_CORE_READ(inode, i_rdev);
+
+	u32 major = dev >> 20;
+	u32 minor = dev & 0xfffff;
+
+	if ((iodev->major != major) || (iodev->minor != minor)) {
+		return 0;
+	}
 
 	u64 *val = bpf_map_lookup_elem(&syscall_count, &key);
 	if (val) { 
@@ -76,11 +102,10 @@ EOF
 		cat >> "src/$FILE_HDR.bpf.c" <<EOF
 
 SEC("kprobe/$line")
-int BPF_KPROBE_$it(struct pt_regs *ctx) { 
-	return increment_counter(${modified//./__});
+int kprobe_$line(struct pt_regs *ctx) {
+	return increment_counter(${modified//./__}, ctx);
 }
 EOF
-	((it++))
 	done <<< "$(cat "$FILE_KSYMS")"
 }
 

--- a/scripts/generate_bpf_programs.sh
+++ b/scripts/generate_bpf_programs.sh
@@ -77,7 +77,8 @@ int increment_counter(u32 key, struct pt_regs *ctx) {
 
 	struct file *file = (struct file *)PT_REGS_PARM1(ctx);
 	struct inode *inode = BPF_CORE_READ(file, f_inode);
-	dev_t dev = BPF_CORE_READ(inode, i_rdev);
+	struct super_block *sb = BPF_CORE_READ(inode, i_sb);
+	dev_t dev = BPF_CORE_READ(sb, s_dev);
 
 	u32 major = dev >> 20;
 	u32 minor = dev & 0xfffff;

--- a/scripts/setup_fs.sh
+++ b/scripts/setup_fs.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+fallocate -l 10G ext4.disk
+loop_dev=$(losetup -f --show ext4.disk)
+mkfs.ext4 "$loop_dev"
+mount "$loop_dev" /mnt

--- a/src/iofilter.h
+++ b/src/iofilter.h
@@ -1,0 +1,9 @@
+#ifndef IO_FILTER_H_
+#define IO_FILTER_H_
+
+struct iofilter_dev {
+	unsigned int major;
+	unsigned int minor;
+};
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,12 @@
 #include <bpf/libbpf.h>
 #include <sys/resource.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <csignal>
 #include <cstdint>
+#include <iostream>
 
+#include "iofilter.h"
 #include "tracer.skel.h"
 #include "tracer.h"
 
@@ -12,31 +16,56 @@ static void signal_handler(int sig) {
 	g_terminate = true;
 }
 
-int main() {
+int main(int argc, char *argv[]) {
 	int ret = 0;
 	uint64_t value = 0;
+	struct stat sb;
+
+	if (argc != 2) {
+		std::cerr << "Usage: " << argv[0] << " <block device>" << std::endl;
+		return 1;
+	}
 
 	std::signal(SIGINT, signal_handler);
 
-	struct rlimit r = {RLIM_INFINITY, RLIM_INFINITY};
+	struct rlimit r = { RLIM_INFINITY, RLIM_INFINITY };
 	setrlimit(RLIMIT_MEMLOCK, &r);
+
+	ret = lstat(argv[1], &sb);
+	if (ret) {
+		std::cerr << "stat: " << strerror(errno);
+		return 1;
+	}
 
 	struct tracer_bpf *skel = tracer_bpf__open();
 	if (!skel) {
-		fprintf(stderr, "Failed to open eBPF skeleton\n");
+		std::cerr << "Failed to open eBPF skeleton" << std::endl;
 		return 1;
 	}
 
 	ret = tracer_bpf__load(skel);
 	if (ret) {
-		fprintf(stderr, "Failed to load eBPF skeleton\n");
+		std::cerr << "Failed to load eBPF skeleton" << std::endl;
+		tracer_bpf__destroy(skel);
+		return 1;
+	}
+
+	if (S_ISBLK(sb.st_mode)) {
+		struct iofilter_dev iodev;
+		iodev.major = major(sb.st_rdev);
+		iodev.minor = minor(sb.st_rdev);
+
+		int key = 0;
+		bpf_map__update_elem(skel->maps.iofilter, &key, sizeof(int), &iodev, sizeof(struct iofilter_dev), BPF_NOEXIST);
+	} else {
+		std::cerr << argv[1] << " is not a block device" << std::endl;
 		tracer_bpf__destroy(skel);
 		return 1;
 	}
 
 	ret = tracer_bpf__attach(skel);
 	if (ret) {
-		fprintf(stderr, "Failed to attach eBPF programs\n");
+		std::cerr << "Failed to attach eBPF programs" << std::endl;
 		tracer_bpf__destroy(skel);
 		return 1;
 	}
@@ -45,11 +74,11 @@ int main() {
 		sleep(1);
 	}
 
-	printf("\n");
+	std::cout << std::endl;
 	for (unsigned int fn = 0; fn < NUM_KSYMS; fn++) {
 		ret = bpf_map__lookup_elem(skel->maps.syscall_count, &fn, sizeof(uint32_t), &value, sizeof(uint64_t), 0);
 		if (!ret) {
-			printf("%s: %lu\n", ksyms_enum_to_string(static_cast<enum ksyms>(fn)), value);
+			std::cout << ksyms_enum_to_string(static_cast<enum ksyms>(fn)) << ": " << value << std::endl;
 		}
 	}
 


### PR DESCRIPTION
Monitoring the OS drive means no isolation from other processes. This allows users to specify a partition or loopback device that is isolated from the main OS drive.